### PR TITLE
fix `install_requires` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'joblib',
         'matplotlib',
-        'sklearn',
+        'scikit-learn',
         'numpy'
     ],
     classifiers=[],


### PR DESCRIPTION
fix `install_requires` in setup.py. Specifically change sklearn to scikit-learn because sklearn is deprecated and it might show error "exit code 1" when trying install for the first time